### PR TITLE
Add computed defaults for options

### DIFF
--- a/adios/tests.nix
+++ b/adios/tests.nix
@@ -52,6 +52,22 @@ let
       };
     };
 
+    withDependentOptions = _: {
+      name = "withDependentOption";
+      options = {
+        a = {
+          type = types.string;
+          default = "a";
+        };
+        b = {
+          type = types.string;
+          defaultFunc = args: "${args.a}-computed";
+        };
+      };
+      impl = args: {
+        inherit args;
+      };
+    };
   };
 
 in
@@ -154,6 +170,25 @@ in
         };
       };
       expected = null;
+    };
+  };
+
+  # Check that dependent options work
+  dependentOptions = {
+    testDependentDefault = {
+      expr = (testModules.withDependentOptions { }).args;
+      expected = {
+        a = "a";
+        b = "a-computed";
+      };
+    };
+
+    testDependentArg = {
+      expr = (testModules.withDependentOptions { a = "b"; }).args;
+      expected = {
+        a = "b";
+        b = "b-computed";
+      };
     };
   };
 }

--- a/adios/types.nix
+++ b/adios/types.nix
@@ -67,11 +67,21 @@ let
             nixUnitTests
           ]).verify;
 
-      option = struct "option" {
-        inherit type;
-        default = optionalAttr any;
-        description = optionalAttr string;
-      };
+      option =
+        (struct "option" {
+          inherit type;
+          default = optionalAttr any;
+          defaultFunc = optionalAttr types.function;
+          description = optionalAttr string;
+        }).override
+          {
+            verify =
+              option:
+              if option ? default && option ? defaultFunc then
+                "'default' & 'defaultFunc' are mutually exclusive"
+              else
+                null;
+          };
 
       subOptions = struct "subOptions" {
         inherit options;
@@ -79,6 +89,7 @@ let
         # Make fields used for normal options non-permitted
         type = neverAttr;
         default = neverAttr;
+        defaultFunc = neverAttr;
       };
 
       options = attrsOf (union [


### PR DESCRIPTION
This adds a feature to define option defaults that depend on other options:
``` nix
{
  name = "test";

  options = {
    a = {
      type = types.string;
      default = "a";
    };

    b = {
      type = types.string;
      defaultFunc = args: "${args.a}-computed";
    };
  };
```

Additionally this change also stops wrapping all unpassed options in errors. This means that the `impl` function will now only receive what has either:
- Defined as a default using `default = "foo";`
- Passed explicitly
- Defined as a computed default using `defaultFunc = args: args.a;`

Constructed errors are still raised if you try to access a default externally using `myModule.defaults.foo`.

Closes #1
Closes #2