### PR TITLE
adios/adios: add publish/subscribe model

### DIFF
--- a/adios/default.nix
+++ b/adios/default.nix
@@ -27,6 +27,7 @@ let
     concatStringsSep
     intersectAttrs
     functionArgs
+    typeOf
     ;
 
   optionalAttrs = cond: attrs: if cond then attrs else { };
@@ -156,6 +157,14 @@ let
     {
       options = checkOptionsType "${errorPrefix} options definition" (def.options or { });
 
+      publish = checkType "${errorPrefix}: while checking 'publish'" types.modules.publish (
+        def.publish or [ ]
+      );
+
+      subscribe = checkType "${errorPrefix}: while checking 'subscribe'" types.modules.subscribe (
+        def.subscribe or [ ]
+      );
+
       modules = mapAttrs (_: loadModule) (def.modules or { });
 
       lib = checkType "${errorPrefix}: while checking 'lib'" types.modules.lib (def.lib or { });
@@ -173,7 +182,21 @@ let
     })
     // (optionalAttrs (def ? impl) {
       impl = checkType "${errorPrefix}: while checking 'impl'" types.function def.impl;
-    });
+    })
+    // (optionalAttrs (def ? contract) (
+      if def ? inputs && def.inputs != { } then
+        throw "${errorPrefix}: a contract module cannot have 'inputs'"
+      else if def ? publish && def.publish != [ ] then
+        throw "${errorPrefix}: a contract module cannot have 'publish'"
+      else if def ? subscribe && def.subscribe != [ ] then
+        throw "${errorPrefix}: a contract module cannot have 'subscribe'"
+      else
+        {
+          contract =
+            checkType "${errorPrefix}: while checking 'contract'" types.modules.contract
+              def.contract;
+        }
+    ));
 
   # Merge lhs & rhs recursing into suboptions
   mergeOptionsUnchecked =
@@ -235,9 +258,103 @@ let
             module.modules.${tok}
         ) module (tail tokens);
 
+  /**
+      Walk the module tree and build a registry of contract publishers and subscribers.
+      This avoids walking the tree again if multiple subscribers exist.
+      Validates that publish/subscribe targets point to modules with `contract`.
+
+    {
+      # What is being published
+      "/user" = {
+        # The 'name' of the contract
+        # - result.${name}
+        # - subscription.${name}
+        name = "user";
+        publishers = [
+          # Who publishes
+          "/producer1"
+          "/producer2"
+        ];
+        subscribers = [
+          # Who subscribes
+          "/users";
+        ];
+      };
+    }
+  */
+  buildRegistry =
+    root:
+    let
+      walk =
+        modulePath': module:
+        let
+          modulePath = "/" + concatStringsSep "/" modulePath';
+        in
+        (concatMap (
+          contractPath:
+          let
+            contractMod = getModule root contractPath;
+          in
+          if !(contractMod ? contract) then
+            throw "Module '${modulePath}' publishes to '${contractPath}', but that module has no 'contract' field"
+          else
+            [
+              {
+                inherit contractPath;
+                type = "publisher";
+                path = modulePath;
+              }
+            ]
+        ) module.publish)
+        ++ (concatMap (
+          contractPath:
+          let
+            contractMod = getModule root contractPath;
+          in
+          if !(contractMod ? contract) then
+            throw "Module '${modulePath}' subscribes to '${contractPath}', but that module has no 'contract' field"
+          else
+            [
+              {
+                inherit contractPath;
+                type = "subscriber";
+                path = modulePath;
+              }
+            ]
+        ) module.subscribe)
+        # Recurse into child modules
+        ++ concatMap (moduleName: walk (modulePath' ++ [ moduleName ]) module.modules.${moduleName}) (
+          attrNames module.modules
+        );
+
+      entries = walk [ ] root;
+
+      # Group by contract path
+      grouped = foldl' (
+        acc: entry:
+        let
+          prev =
+            acc.${entry.contractPath} or {
+              name = contractNameFromPath entry.contractPath;
+              publishers = [ ];
+              subscribers = [ ];
+            };
+        in
+        acc
+        // {
+          ${entry.contractPath} =
+            if entry.type == "publisher" then
+              prev // { publishers = prev.publishers ++ [ entry.path ]; }
+            else
+              prev // { subscribers = prev.subscribers ++ [ entry.path ]; };
+        }
+      ) { } entries;
+    in
+    grouped;
+
   # Resolve required module dependencies for defined config options
   resolveTree =
-    scope: moduleNames:
+    scope: registry: moduleNames:
     listToAttrs (
       map
         (x: {
@@ -252,9 +369,22 @@ let
           # Discover module dependencies
           operator =
             { key }:
-            map (input: {
-              key = absModulePath key input.path;
-            }) (attrValues (getModule scope key).inputs);
+            let
+              mod = getModule scope key;
+              # Regular input dependencies
+              inputDeps = map (input: {
+                key = absModulePath key input.path;
+              }) (attrValues mod.inputs);
+              # Subscribe dependencies: pull in all publishers + the contract module
+              subscribeDeps = concatMap (
+                contractPath:
+                let
+                  entry = registry.${contractPath};
+                in
+                [ { key = contractPath; } ] ++ map (pub: { key = pub; }) entry.publishers
+              ) mod.subscribe;
+            in
+            inputDeps ++ subscribeDeps;
         })
     );
 
@@ -264,6 +394,8 @@ let
       options,
       # Resolved modules attrset
       resolution,
+      # Contract registry
+      registry,
       # Previous eval memoisation
       memoArgs ? { },
       memoResults ? { },
@@ -272,17 +404,51 @@ let
       # Computed options/inputs for each module in resolution
       args =
         mapAttrs (modulePath: module: {
-          inputs = mapAttrs (_: input:
-            args.${absModulePath modulePath input.path}.options
-          ) module.inputs;
+          inputs = mapAttrs (_: input: args.${absModulePath modulePath input.path}.options) module.inputs;
 
           # Map input names to the impl return value of the referenced module
-          results = mapAttrs (inputName: input:
-            let depPath = absModulePath modulePath input.path;
-            in if results ? ${depPath}
-               then results.${depPath}
-               else throw "Module '${depPath}' (input '${inputName}' of '${modulePath}') has no impl, so it has no result"
+          results = mapAttrs (
+            inputName: input:
+            let
+              depPath = absModulePath modulePath input.path;
+            in
+            if results ? ${depPath} then
+              results.${depPath}
+            else
+              throw "Module '${depPath}' (input '${inputName}' of '${modulePath}') has no impl, so it has no result"
           ) module.inputs;
+
+          # Compute subscriptions: for each subscribed contract, merge all published values
+          subscriptions = listToAttrs (
+            map (
+              contractPath:
+              let
+                entry = registry.${contractPath};
+                contractMod = resolution.${contractPath};
+                # Gather the published values from each publisher's result
+                publishers = builtins.listToAttrs (
+                  map (
+                    pubPath:
+                    let
+                      pubResult = results.${pubPath};
+                    in
+                    {
+                      name = pubPath;
+                      value =
+                        if pubResult ? ${entry.name} then
+                          pubResult.${entry.name}
+                        else
+                          throw "Module '${pubPath}' publishes to '${contractPath}' but its result has no '${entry.name}' attribute";
+                    }
+                  ) entry.publishers
+                );
+              in
+              {
+                name = entry.name;
+                value = contractMod.contract.merge publishers;
+              }
+            ) module.subscribe
+          );
 
           options = computeOptions {
             args = args.${modulePath};
@@ -293,7 +459,7 @@ let
         }) resolution
         // memoArgs;
 
-      inherit options resolution;
+      inherit options resolution registry;
 
       # Module call results for each callable module in resolution
       results =
@@ -307,7 +473,9 @@ let
               [
                 {
                   name = modulePath;
-                  value = callFunction module.impl args.${modulePath};
+                  value = validatePublished (p: resolution.${p}) modulePath module.publish (
+                    callFunction module.impl args.${modulePath}
+                  );
                 }
               ]
             else
@@ -331,12 +499,33 @@ let
           _: input: (getModule root (absModulePath modulePath input.path)).args.options
         ) module.inputs;
 
-        results = mapAttrs (inputName: input:
-          let dep = getModule root (absModulePath modulePath input.path);
-          in if dep ? impl
-             then callFunction dep.impl dep.args
-             else throw "Module at input '${inputName}' of '${modulePath}' has no impl, so it has no result"
+        results = mapAttrs (
+          inputName: input:
+          let
+            dep = getModule root (absModulePath modulePath input.path);
+          in
+          if dep ? impl then
+            callFunction dep.impl dep.args
+          else
+            throw "Module at input '${inputName}' of '${modulePath}' has no impl, so it has no result"
         ) module.inputs;
+
+        # Subscriptions are only available in the tree eval context (evalModuleTree).
+        # Calling a subscribing module directly via __functor outside that context
+        # will throw when accessing subscriptions.
+        subscriptions =
+          builtins.mapAttrs
+            (
+              _: _: throw "Module '${modulePath}' has subscriptions but was called outside the tree eval context"
+            )
+            (
+              listToAttrs (
+                map (contractPath: {
+                  name = contractNameFromPath contractPath;
+                  value = null;
+                }) module.subscribe
+              )
+            );
 
         options = computeOptions {
           inherit args;
@@ -348,6 +537,104 @@ let
     in
     args;
 
+  /**
+    Extracts the contract name from a contract module path.
+
+    The contract name is used as the key for:
+    - publisher results: `result.${name}`
+    - subscriber subscriptions: `subscriptions.${name}`
+
+    # Arguments
+    - `path`: A contract module path (e.g. "/foo/bar/user")
+
+    # Returns
+    The last segment of the path (e.g. "user")
+
+    # Consumers
+    - `buildRegistry`: to set `name` on registry entries
+    - `validatePublished`: to look up the published key in a module's result
+  */
+  contractNameFromPath =
+    path:
+    let
+      tokens = filter isString (split "/" path);
+    in
+    builtins.elemAt tokens (builtins.length tokens - 1);
+
+  /**
+    Validates a module's published outputs against their contracts.
+
+    Checks that the result contains the expected key for each
+    published contract, then validates every element in the collection
+    by running it through the contract module's options and impl.
+
+    # Arguments
+    - getContractMod: lookup function
+      - `evalModuleTree` passes `(p: resolution.${p})`
+      - `__functor` passes `(p: getModule tree' p)`
+    - `modulePath`: Path of the publishing module (for error reporting)
+    - `publishPaths`: list of e.g. `[ "/user" "/etcFile" ]`
+    - `result`: The return value of `impl`
+
+    # Returns
+
+    The result with published attributes replaced by their validated versions.
+    NOTE: The contract may apply transformations that go beyond type checking.
+
+    # Consumers
+    - `evalModuleTree.results`: validates results during tree evaluation
+    - `applyTreeOptions.__functor`: validates results on direct module calls
+  */
+  validatePublished =
+    getContractMod: modulePath: publishPaths: result:
+    if publishPaths == [ ] then
+      result
+    else
+      let
+        publishNames = map contractNameFromPath publishPaths;
+        missing = filter (name: !result ? ${name}) publishNames;
+      in
+      if missing != [ ] then
+        throw ''
+          Module '${modulePath}' declares to publish '[ ${concatStringsSep " " missing} ]' but impl doesnt return it
+        ''
+      else
+        let
+          validated = listToAttrs (
+            map (
+              contractPath:
+              let
+                name = contractNameFromPath contractPath;
+                raw = result.${name};
+                contractMod = getContractMod contractPath;
+                validate =
+                  resource:
+                  callFunction contractMod.impl {
+                    options = computeOptions {
+                      args = {
+                        options = resource;
+                      };
+                      errorPrefix = "while validating '${name}' published by '${modulePath}'";
+                      options = contractMod.options;
+                      passedArgs = resource;
+                    };
+                  };
+              in
+              {
+                inherit name;
+                value =
+                  if isAttrs raw then
+                    mapAttrs (_: validate) raw
+                  else if builtins.isList raw then
+                    map validate raw
+                  else
+                    throw "Module '${modulePath}' published '${name}' must be an attrset or list, got ${typeOf raw}";
+              }
+            ) publishPaths
+          );
+        in
+        result // validated;
+
   # Apply options to a module tree, returning a new module tree where modules can be called
   # with their inputs already wired up & options partially applied.
   applyTreeOptions =
@@ -358,6 +645,8 @@ let
       options,
       # Attrset of computed args from tree eval context
       args,
+      # Contract registry
+      registry,
     }:
     let
       recurse =
@@ -396,7 +685,7 @@ let
                     else
                       # Re-compute args fixpoint with passed args
                       {
-                        inherit (self.args) inputs results;
+                        inherit (self.args) inputs results subscriptions;
                         options = computeOptions {
                           inherit args;
                           inherit (module) options;
@@ -406,8 +695,7 @@ let
                         };
                       };
                 in
-                # Call implementation
-                callFunction self.impl args;
+                validatePublished (p: getModule tree' p) modulePath self.publish (callFunction self.impl args);
             };
         in
         self;
@@ -426,6 +714,8 @@ let
     }:
     optionsType.check options (
       let
+        registry = prevEval.registry;
+
         # TODO: Filter nulled out options
         options' = prevEval.options // options;
 
@@ -442,7 +732,7 @@ let
           if newModuleNames != [ ] then
             (
               if resolve then
-                resolveTree root (attrNames options')
+                resolveTree root registry (attrNames options')
               else
                 throw ''
                   Module overriding caused re-resolving, which is disabled.
@@ -463,23 +753,40 @@ let
               { key }:
               concatMap (
                 name:
-                let mod = resolution.${name};
-                in if any (input: absModulePath name input.path == key) (attrValues mod.inputs)
-                   then [ { key = name; } ]
-                   else [ ]
+                let
+                  mod = resolution.${name};
+                in
+                # Inputs invalidate
+                if any (input: absModulePath name input.path == key) (attrValues mod.inputs) then
+                  [ { key = name; } ]
+                # Pub/sub invalidate
+                # 1. Contract changes -> invalidate all subscribers
+                # 2. Publisher changes -> invalidate all subscribers
+                else if
+                  any (
+                    contractPath:
+                    let
+                      entry = registry.${contractPath};
+                    in
+                    key == contractPath || builtins.elem key entry.publishers
+                  ) mod.subscribe
+                then
+                  [ { key = name; } ]
+                else
+                  [ ]
               ) resolutionNames;
           });
 
         # Overriden eval context
         evalParams = evalModuleTree {
-          inherit resolution;
+          inherit resolution registry;
           options = options';
           memoArgs = removeAttrs prevEval.args diff;
           memoResults = removeAttrs prevEval.results diff;
         };
         # Tree context
         tree = applyTreeOptions {
-          inherit root;
+          inherit root registry;
           options = options';
           inherit (evalParams) args;
         };
@@ -496,20 +803,24 @@ let
     unloadedRoot:
     let
       root = loadModule unloadedRoot;
+      registry = buildRegistry root;
     in
     {
       options ? { },
     }:
     let
+      # Collect all subscriber module paths from registry so they're always resolved
+      subscriberPaths = concatMap (regEntry: regEntry.subscribers) (attrValues registry);
+
       # Overriden eval context
       evalParams =
         let
-          resolution = resolveTree root (attrNames options);
+          resolution = resolveTree root registry (attrNames options ++ subscriberPaths);
         in
-        evalModuleTree { inherit resolution options; };
+        evalModuleTree { inherit resolution registry options; };
       # Tree context
       tree = applyTreeOptions {
-        inherit root options;
+        inherit root options registry;
         inherit (evalParams) args;
       };
     in

--- a/adios/types.nix
+++ b/adios/types.nix
@@ -75,6 +75,16 @@ let
 
     inputs = attrsOf modules.input;
 
+    contract = struct "contract" {
+      merge = function;
+    };
+
+    # list of path strings, e.g. [ "/user" "/etcFile" ]
+    publish = korora.listOf (typedef "pathstring" isString);
+
+    # list of path strings
+    subscribe = korora.listOf (typedef "pathstring" isString);
+
     lib = attrs;
   };
 


### PR DESCRIPTION
Modules should be able to contribute to larger data-aggregations This design involves three parts:
- Contract: describe the shape of a resource in a collection
- Publish: push data to a collection
- Subscribe: consume data from the collection

The contract module is responsible to provide a merge function, which is used to aggregate the data from multiple publishers.

This branch is now backed by: https://github.com/hsjobeki/ThermOS.
this is still a research project; It should demonstrate that you can build an actual os from this branch.
Because you can build an OS, it doesnt mean this feature is correct, but it demonstrates the usefulness, that wouldn't be possible otherwise, or would require statically hard wired dependencies everywhere. (Which is impractical)

### Example

```nix 
let
  adios = import ./adios;
  tree = adios {
    name = "root";
    modules = {
      # Contract: defines the shape + how to merge
      fruit = {
        contract = {
          merge = publishers: builtins.concatLists (builtins.attrValues publishers);
        };
        options.name = {
          type = adios.types.str;
        };
        impl = { options }: options;
      };

      # Publisher A
      alice = {
        publish = [ "/fruit" ];
        impl = _: {
          fruit = [
            { name = "apple"; }
            { name = "banana"; }
          ];
        };
      };

      # Publisher B
      bob = {
        publish = [ "/fruit" ];
        impl = _: {
          fruit = [
            { name = "cherry"; }
          ];
        };
      };

      # Subscriber
      basket = {
        subscribe = [ "/fruit" ];
        impl =
          { subscriptions }:
          let
            allFruit = subscriptions.fruit;
          in
          {
            summary = builtins.map (f: f.name) allFruit;
          };
      };
    };
  } { };

in
tree.modules.basket { }
# { summary = [ "apple" "banana" "cherry" ]; }
```  

``